### PR TITLE
Add _category_ to APS payload

### DIFF
--- a/src/main/java/apns/DefaultPushNotificationService.java
+++ b/src/main/java/apns/DefaultPushNotificationService.java
@@ -170,6 +170,9 @@ public class DefaultPushNotificationService implements PushNotificationService {
             } else if (pn.getComplexAlert() != null) {
                 dict.put("alert", createAlertDict(pn.getComplexAlert()));
             }
+            if (pn.getCategory() != null) {
+                dict.put("category", pn.getCategory());
+            }
             jo.put("aps", dict);
         }
 

--- a/src/main/java/apns/PushNotification.java
+++ b/src/main/java/apns/PushNotification.java
@@ -16,6 +16,7 @@ public class PushNotification implements Serializable {
     private String mSound;
     private boolean mContentAvailable;
     private Collection<String> mDeviceTokens;
+    private String mCategory;
     private Map<String, Object> mCustomPayload = new HashMap<>();
 
     public Integer getBadge() {
@@ -74,6 +75,15 @@ public class PushNotification implements Serializable {
 
     public PushNotification setContentAvailable(boolean available) {
         mContentAvailable = available;
+        return this;
+    }
+    
+    public String getCategory() {
+        return mCategory;
+    }
+
+    public PushNotification setCategory(String category) {
+        mCategory = category;
         return this;
     }
 

--- a/src/test/java/apns/DefaultPushNotificationServiceTest.java
+++ b/src/test/java/apns/DefaultPushNotificationServiceTest.java
@@ -15,6 +15,7 @@ public class DefaultPushNotificationServiceTest {
     public static final String KEY_BADGE = "badge";
     public static final String KEY_SOUND = "sound";
     public static final String KEY_CONTENT_AVAILABLE = "content-available";
+    public static final String KEY_CATEGORY = "category";
 
     public static final String KEY_BODY = "body";
     public static final String KEY_ACTION_LOC_KEY = "action-loc-key";
@@ -29,6 +30,7 @@ public class DefaultPushNotificationServiceTest {
     private static final String LOC_KEY = "loc_key_value";
     private static final String[] LOC_ARGS = {"a", "b", "c"};
     private static final String LAUNCH_IMAGE = "launch_image_value";
+    private static final String CATEGORY = "REQUEST_CATEGORY";
 
     public static final String KEY_CP = "cp";
     private static final String SOME_KEY_1 = "skey1";
@@ -52,6 +54,7 @@ public class DefaultPushNotificationServiceTest {
             Assert.assertNull(aps.opt(KEY_BADGE));
             Assert.assertNull(aps.opt(KEY_SOUND));
             Assert.assertNull(aps.opt(KEY_CONTENT_AVAILABLE));
+            Assert.assertNull(aps.opt(KEY_CATEGORY));
         }
 
         // --
@@ -68,7 +71,7 @@ public class DefaultPushNotificationServiceTest {
 
         // --
         {
-            PushNotification pn = new PushNotification().setBadge(BADGE).setContentAvailable(true);
+            PushNotification pn = new PushNotification().setBadge(BADGE).setContentAvailable(true).setCategory(CATEGORY);
             JSONObject json = createPayloadJson(pn);
 
             JSONObject aps = json.getJSONObject(KEY_APS);
@@ -76,6 +79,7 @@ public class DefaultPushNotificationServiceTest {
             Assert.assertNull(aps.opt(KEY_ALERT));
             Assert.assertNull(aps.opt(KEY_SOUND));
             Assert.assertEquals(1, aps.getInt(KEY_CONTENT_AVAILABLE));
+            Assert.assertEquals(CATEGORY, aps.getString(KEY_CATEGORY));
         }
 
         // --


### PR DESCRIPTION
Category was missing from APS payload. ( i think our iOS developer needed this to properly bring up iWatch app)

https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW1